### PR TITLE
Fix DirectionInput event listener cleanup

### DIFF
--- a/DirectionInput.js
+++ b/DirectionInput.js
@@ -15,26 +15,29 @@ class DirectionInput {
 
 	}
 
-	get direction() {
-		return this.heldDirections[0]
-	}
-	init() {
-		document.addEventListener("keydown", e => {
-			const dir = this.map[e.key]
-			if (dir && this.heldDirections.indexOf(dir) == -1) {
-				this.heldDirections.unshift(dir)
-			}
-		})
-		document.addEventListener("keyup", e => {
-			const dir = this.map[e.key]
-			const index = this.heldDirections.indexOf(dir)
-			if (index > -1) {
-				this.heldDirections.splice(index, 1)
-			}
-		})
-	}
-	destroy() {
-		document.removeEventListener("keydown", this.onKeyDown);
-		document.removeEventListener("keyup", this.onKeyUp);
-	}
+        get direction() {
+                return this.heldDirections[0]
+        }
+        init() {
+                this.onKeyDown = (e) => {
+                        const dir = this.map[e.key]
+                        if (dir && this.heldDirections.indexOf(dir) == -1) {
+                                this.heldDirections.unshift(dir)
+                        }
+                }
+                this.onKeyUp = (e) => {
+                        const dir = this.map[e.key]
+                        const index = this.heldDirections.indexOf(dir)
+                        if (index > -1) {
+                                this.heldDirections.splice(index, 1)
+                        }
+                }
+
+                document.addEventListener("keydown", this.onKeyDown)
+                document.addEventListener("keyup", this.onKeyUp)
+        }
+        destroy() {
+                document.removeEventListener("keydown", this.onKeyDown);
+                document.removeEventListener("keyup", this.onKeyUp);
+        }
 }


### PR DESCRIPTION
## Summary
- store keydown/keyup handlers on DirectionInput so destroy removes them

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b424873ec832aa8029d2add798911