### PR TITLE
Add destroy lifecycle for game objects

### DIFF
--- a/GameObject.js
+++ b/GameObject.js
@@ -2,7 +2,9 @@ class GameObject {
 	constructor(config) {
 		this.id = null;
 
-		this.isMounted = false
+                this.isMounted = false
+                this.map = null;
+                this.behaviorTimeout = null;
 		this.x = config.x || 0
 		this.y = config.y || 0
 		this.direction = config.direction || "down";
@@ -19,36 +21,49 @@ class GameObject {
 	update() {
 
 	}
-	mount(map) {
-		this.isMounted = true
-		map.addWall(this.x, this.y)
+        mount(map) {
+                this.isMounted = true
+                this.map = map;
+                map.addWall(this.x, this.y)
 
-		setTimeout(() => {
-			this.doBehaviorEvent(map)
+                this.behaviorTimeout = setTimeout(() => {
+                        this.doBehaviorEvent(map)
 
-		}, 10)
-	}
+                }, 10)
+        }
 
-	async doBehaviorEvent(map) {
-		//dont do anything if there is a more important cutscene 
-		//or I dont have config to do anyting
-		if (map.isCutscenePlaying || this.behaviorLoop.length === 0) {
-			return
-		}
+        destroy() {
+                this.isMounted = false;
+                if (this.map) {
+                        this.map.removeWall(this.x, this.y);
+                        this.map = null;
+                }
+                if (this.behaviorTimeout) {
+                        clearTimeout(this.behaviorTimeout);
+                        this.behaviorTimeout = null;
+                }
+        }
 
-		//Setting up our event with relevant info
-		let eventConfig = this.behaviorLoop[this.behaviorLoopIndex];
-		eventConfig.who = this.id;
-		//Create an event instance out of our next event config
-		const eventHandler = new OverworldEvent({ map, event: eventConfig });
-		await eventHandler.init();
+        async doBehaviorEvent(map) {
+                //dont do anything if there is a more important cutscene
+                //or I dont have config to do anything or object is unmounted
+                if (!this.isMounted || map.isCutscenePlaying || this.behaviorLoop.length === 0) {
+                        return
+                }
 
-		//Setting the next event to fire
-		this.behaviorLoopIndex += 1;
-		if (this.behaviorLoopIndex === this.behaviorLoop.length) {
-			this.behaviorLoopIndex = 0;
-		}
+                //Setting up our event with relevant info
+                let eventConfig = this.behaviorLoop[this.behaviorLoopIndex];
+                eventConfig.who = this.id;
+                //Create an event instance out of our next event config
+                const eventHandler = new OverworldEvent({ map, event: eventConfig });
+                await eventHandler.init();
 
-		this.doBehaviorEvent(map)
-	}
+                //Setting the next event to fire
+                this.behaviorLoopIndex += 1;
+                if (this.behaviorLoopIndex === this.behaviorLoop.length) {
+                        this.behaviorLoopIndex = 0;
+                }
+
+                this.doBehaviorEvent(map)
+        }
 }

--- a/Overworld.js
+++ b/Overworld.js
@@ -64,14 +64,17 @@ class Overworld {
 		};
 		document.addEventListener("PersonWalkingComplete", this.onHeroWalkComplete);
 	}
-	startMap(mapConfig) {
-		//Stop game loop and unbind everything
-		this.stopGameLoop?.()
-		this.unbindHeroPosition?.();
-		this.directionInput?.destroy?.();
+        startMap(mapConfig) {
+                //Stop game loop and unbind everything
+                this.stopGameLoop?.()
+                this.unbindHeroPosition?.();
+                this.directionInput?.destroy?.();
 
-		//Change the map
-		this.map = new OverworldMap(mapConfig);
+                //Unmount old map objects
+                this.map?.unmountObjects?.();
+
+                //Change the map
+                this.map = new OverworldMap(mapConfig);
 		this.map.overworld = this;
 		this.map.mountObjects();
 

--- a/OverworldMap.js
+++ b/OverworldMap.js
@@ -26,14 +26,20 @@ class OverworldMap {
 		const { x, y } = utils.nextPosition(currentX, currentY, direction)
 		return this.walls[`${x},${y}`] || false
 	}
-	mountObjects() {
-		Object.keys(this.gameObjects).forEach((key) => {
-			let object = this.gameObjects[key]
-			object.id = key
-			//TODO: determine if objects should be mounted
-			object.mount(this)
-		})
-	}
+        mountObjects() {
+                Object.keys(this.gameObjects).forEach((key) => {
+                        let object = this.gameObjects[key]
+                        object.id = key
+                        //TODO: determine if objects should be mounted
+                        object.mount(this)
+                })
+        }
+
+        unmountObjects() {
+                Object.values(this.gameObjects).forEach((object) => {
+                        object.destroy?.();
+                });
+        }
 
 	async startCutscene(events) {
 		this.isCutscenePlaying = true;


### PR DESCRIPTION
## Summary
- Call `unmountObjects` before switching maps so old objects are cleaned up
- Add `OverworldMap.unmountObjects` to destroy each game object
- Introduce `GameObject.destroy` to remove walls, cancel timeouts, and mark unmounted

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689b459021dc832aac54b05e75e1ac9c